### PR TITLE
fix: Pascal case for fully-lowercase types

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -46,6 +46,7 @@ export class TypeGenerator {
       }
     } while (m);
 
+    result = result.replace(/^./, result[0].toUpperCase()) // ensure first letter is capitalized
     return result;
   }
 

--- a/test/type-generator.naming.test.ts
+++ b/test/type-generator.naming.test.ts
@@ -16,4 +16,10 @@ describe('normalizeTypeName', () => {
     expect(TypeGenerator.normalizeTypeName('StorageIO')).toEqual('StorageIo');
     expect(TypeGenerator.normalizeTypeName('AFoo')).toEqual('AFoo');
   });
+
+  test('Lowercase words are converted to PascalCase', () => {
+    expect(TypeGenerator.normalizeTypeName('attributemanifests')).toEqual('Attributemanifests');
+    expect(TypeGenerator.normalizeTypeName('attributemanifestsOptions')).toEqual('AttributemanifestsOptions');
+    expect(TypeGenerator.normalizeTypeName('attributeMANIFESTSOptions')).toEqual('AttributeManifestsOptions');
+  });
 });


### PR DESCRIPTION
Seems like the `normalizeTypeName` wasn't handling all-lowercase type names which is causing an issues in `cdk8s`. We could handle it there, but I think here makes more sense as this function should be converting to pascal case.


Fixes https://github.com/awslabs/cdk8s/issues/267

Signed-off-by: campionfellin <campionfellin@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
