### PR TITLE
feat: type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ const g = new TypeGenerator({
   },
 });
 
-g.addType('Person', {
+// definitions can also be added like this:
+g.addDefinition('Person', {
   required: [ 'name' ],
   properties: {
     name: {
@@ -37,6 +38,9 @@ g.addType('Person', {
     },
   },
 });
+
+// this will emit the specified type & recursively all the referenced types.
+g.emitType('Person');
 
 fs.writeFileSync('gen/ts/person.ts', await g.render());
 ```
@@ -83,6 +87,35 @@ export interface Name {
    * @schema Name#lastName
    */
   readonly lastName: string;
+}
+```
+
+## Use cases
+
+### Type aliases
+
+It is possible to offer an alias to a type definition using `addAlias(from,
+to)`. The type generator will resolve any references to the original type with
+the alias:
+
+```ts
+const gen = new TypeGenerator();
+gen.addDefinition('TypeA', { type: 'object', properties: { ref: { $ref: '#/definitions/TypeB' } } } );
+gen.addDefinition('TypeC', { type: 'object', properties: { field: { type: 'string' } } });
+gen.addAlias('TypeB', 'TypeC');
+
+gen.emitType('TypeA');
+```
+
+This will output:
+
+```ts
+interface TypeA {
+  readonly ref: TypeC;
+}
+
+interface TypeC {
+  readonly field: string;
 }
 ```
 

--- a/test/__snapshots__/type-generator.test.ts.snap
+++ b/test/__snapshots__/type-generator.test.ts.snap
@@ -335,6 +335,47 @@ export interface MyType {
 "
 `;
 
+exports[`type aliases alias to a custom type 1`] = `
+"// this is NewType
+
+/**
+ * @schema TypeB
+ */
+export interface TypeB {
+  /**
+   * @schema TypeB#refToTypeA
+   */
+  readonly refToTypeA?: NewType;
+
+}
+"
+`;
+
+exports[`type aliases alias to a definition 1`] = `
+"/**
+ * @schema TypeA
+ */
+export interface TypeA {
+  /**
+   * @schema TypeA#ref
+   */
+  readonly ref?: TypeC;
+
+}
+
+/**
+ * @schema TypeC
+ */
+export interface TypeC {
+  /**
+   * @schema TypeC#field
+   */
+  readonly field?: string;
+
+}
+"
+`;
+
 exports[`unions constraints are ignored for objects 1`] = `
 "/**
  * @schema TestType


### PR DESCRIPTION
It is now possible to add type aliases to the `TypeGenerator`:

    gen.addAlias('FromMyType', 'ToYourType');

The implication is that every `$ref` to `FromMyType` will be resolved as `ToYourType` instead.

The destination type must either has a definition (added via `definitions` or `addDefinition()`)  or it can also be a custom type added via `emitCustomType()`.

Misc:

- Renamed `addType()` to `emitType()` (soft-deprecation).
- Renamed `addCode()` to `emitCustomType()` (soft-deprecation)
- Added `addDefinition(typeName, schema)`
- Support calling `emitType(name)` without a schema - this will look up the definition of the
  type automatically.

Required in order to implement awslabs/cdk8s#370
