### PR TITLE
fix: quote enum member names starting with a numeric

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -344,7 +344,10 @@ export class TypeGenerator {
         }
 
         // sluggify and turn to UPPER_SNAKE_CASE
-        const memberName = snakeCase(value.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+        let memberName = snakeCase(value.replace(/[^a-z0-9]/gi, '_')).split('_').filter(x => x).join('_').toUpperCase();
+        if (memberName.match(/^\d/)) {
+          memberName = `"${memberName}"`;
+        }
 
         code.line(`/** ${value} */`);
         code.line(`${memberName} = "${value}",`);


### PR DESCRIPTION
Hi,

Using [CDK for Kubernetes](https://github.com/awslabs/cdk8s) which depends on this library. I stumbled upon automatic code generation that resulted in with an enum looking like:

```
export enum HttpProxySpecRoutesRetryPolicyRetryOn {
  /** 5xx */
  5XX = "5xx",
  /** gateway-error */
  GATEWAY_ERROR = "gateway-error",
…
```

Thus being unable to compile TypeScript as the member name is starting with a numeric character:

```
error TS2452: An enum member cannot have a numeric name.
```

This PR adds automatic quoting for member names only if the first character is a numeric one.

Regards